### PR TITLE
Remove stray editor commands and support additional options

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -21,7 +21,6 @@ export default async function handler(req, res) {
       size = 1024,             // 512 | 768 | 1024
       seed                      // opcional
     } = req.body || {};
-nano api/generate.js
     if (!prompt || typeof prompt !== 'string') {
       return res.status(400).json({ error: 'Prompt is required' });
     }
@@ -30,11 +29,14 @@ nano api/generate.js
     const styleMap = {
       'none': undefined,
       'sin preset': undefined,
+      'ninguno': undefined,
       'realista': 'photographic',
       'cinematografico': 'cinematic',
       'cinematográfico': 'cinematic',
       'arte digital': 'digital-art',
+      'arte-digital': 'digital-art',
       'pixel art': 'pixel-art',
+      'pixel': 'pixel-art',
       'anime': 'anime',
       'fantasia': 'fantasy-art',
       'fantasía': 'fantasy-art',
@@ -67,8 +69,10 @@ nano api/generate.js
     const qualityMap = {
       'rapida': 'speed',
       'rápida': 'speed',
+      'fast': 'speed',
       'estandar': 'quality',
       'estándar': 'quality',
+      'standard': 'quality',
       'alta': 'quality'
     };
 

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-nano index.html<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
- clean stray editor command from API handler
- fix HTML doctype line
- accept more style and quality values from UI

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e03d95cd8832cadf359179a9c7049