### PR TITLE
Align image API with frontend and add tests

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -18,10 +18,10 @@ export default async function handler(req, res) {
       style = 'none',          // valores de la UI
       quality = 'estandar',    // 'rapida' | 'estandar' | 'alta'
       aspect_ratio = '1:1',    // '1:1','16:9', etc.
-      size = 1024,             // 512 | 768 | 1024
+      width,
+      height,
       seed                      // opcional
     } = req.body || {};
-nano api/generate.js
     if (!prompt || typeof prompt !== 'string') {
       return res.status(400).json({ error: 'Prompt is required' });
     }
@@ -30,11 +30,17 @@ nano api/generate.js
     const styleMap = {
       'none': undefined,
       'sin preset': undefined,
+      'ninguno': undefined,
       'realista': 'photographic',
       'cinematografico': 'cinematic',
       'cinematográfico': 'cinematic',
       'arte digital': 'digital-art',
+      'arte-digital': 'digital-art',
       'pixel art': 'pixel-art',
+      'pixel': 'pixel-art',
+      'producto': 'product-photo',
+      'retrato': 'portrait',
+      'arquitectura': 'architecture',
       'anime': 'anime',
       'fantasia': 'fantasy-art',
       'fantasía': 'fantasy-art',
@@ -67,8 +73,10 @@ nano api/generate.js
     const qualityMap = {
       'rapida': 'speed',
       'rápida': 'speed',
+      'fast': 'speed',
       'estandar': 'quality',
       'estándar': 'quality',
+      'standard': 'quality',
       'alta': 'quality'
     };
 
@@ -76,15 +84,14 @@ nano api/generate.js
       prompt,
       negative_prompt,
       output_format: 'png',
-      aspect_ratio: arMap[(aspect_ratio || '').toString().trim()] || '1:1',
+      ...(width && height
+          ? { width: Number(width), height: Number(height) }
+          : { aspect_ratio: arMap[(aspect_ratio || '').toString().trim()] || '1:1' }),
       mode: qualityMap[(quality || '').toString().toLowerCase()] || 'quality',
-      ...(styleMap[(style || '').toString().toLowerCase()] 
+      ...(styleMap[(style || '').toString().toLowerCase()]
           ? { style_preset: styleMap[(style || '').toString().toLowerCase()] }
           : {}),
       ...(seed !== undefined && seed !== '' ? { seed: Number(seed) } : {}),
-      // Algunos planes aceptan 'width/height' en vez de 'size'. SD3 con aspect_ratio
-      // no los requiere; si te interesa forzar tamaño, descomenta:
-      // width: Number(size), height: Number(size),
     };
 
     const response = await fetch(
@@ -109,8 +116,8 @@ nano api/generate.js
     }
 
     const buffer = Buffer.from(await response.arrayBuffer());
-    res.setHeader('Content-Type', 'image/png');
-    res.status(200).send(buffer);
+    const base64 = buffer.toString('base64');
+    res.status(200).json({ image: `data:image/png;base64,${base64}` });
   } catch (e) {
     console.error(e);
     res.status(500).json({ error: 'server_error', message: e.message });

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-nano index.html<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8" />

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/generate.js';
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    data: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.data = payload; return this; },
+    setHeader(name, value) { this.headers[name] = value; },
+    send(payload) { this.data = payload; return this; }
+  };
+}
+
+test('returns 405 for non-POST', async () => {
+  const req = { method: 'GET' };
+  const res = mockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 405);
+  assert.deepEqual(res.data, { error: 'Method not allowed' });
+});
+
+test('returns error when missing API key', async () => {
+  const req = { method: 'POST', body: { prompt: 'hi' } };
+  const res = mockRes();
+  delete process.env.STABILITY_API_KEY;
+  await handler(req, res);
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.data, { error: 'Missing STABILITY_API_KEY' });
+});
+
+test('returns base64 image on success', async () => {
+  const req = { method: 'POST', body: { prompt: 'hi', width: 256, height: 256 } };
+  const res = mockRes();
+  process.env.STABILITY_API_KEY = 'test';
+  const originalFetch = global.fetch;
+  const fakePng = new Uint8Array([137,80,78,71]);
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => fakePng.buffer
+  });
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+  }
+  assert.equal(res.statusCode, 200);
+  assert.ok(typeof res.data.image === 'string');
+  assert.ok(res.data.image.startsWith('data:image/png;base64,'));
+});


### PR DESCRIPTION
## Summary
- send generated image as base64 JSON and map UI style/quality values
- add npm test script with coverage for handler success and error cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e03d95cd8832cadf359179a9c7049